### PR TITLE
fix: Ticket welcome message spacing

### DIFF
--- a/resources/views/tickets/index.blade.php
+++ b/resources/views/tickets/index.blade.php
@@ -6,8 +6,8 @@
     <h1>{{ trans('support::messages.title') }}</h1>
 
     @if($infoText !== null)
-        <div class="card mb-4">
-            <div class="card-body pb-0">
+        <div class="card mb-3">
+            <div class="card-body pb-3">
                 {{ $infoText }}
             </div>
         </div>


### PR DESCRIPTION
Before:
![image](https://github.com/Azuriom/Plugin-Support/assets/32937653/a2d41eec-ba57-4f06-b9de-bfff56160b8b)

After:
![image](https://github.com/Azuriom/Plugin-Support/assets/32937653/f94584f3-6863-4eb9-adef-175a0b95998c)
