### PR TITLE
Add ticket link to support notifications

### DIFF
--- a/src/Controllers/Admin/TicketCommentController.php
+++ b/src/Controllers/Admin/TicketCommentController.php
@@ -23,7 +23,7 @@ class TicketCommentController extends Controller
 
         (new AlertNotification(trans('support::messages.tickets.notification')))
             ->from($comment->author)
-            ->link(route('support.tickets.show', $ticket))
+            ->link(route('support.tickets.show', $ticket, false))
             ->send($ticket->author);
 
         $comment->sendDiscordWebhook();

--- a/src/Controllers/Admin/TicketCommentController.php
+++ b/src/Controllers/Admin/TicketCommentController.php
@@ -23,6 +23,7 @@ class TicketCommentController extends Controller
 
         (new AlertNotification(trans('support::messages.tickets.notification')))
             ->from($comment->author)
+            ->link(route('support.tickets.show', $ticket))
             ->send($ticket->author);
 
         $comment->sendDiscordWebhook();


### PR DESCRIPTION
Add a link to the support notification, enabling users to be redirected to the specific ticket page when they click on the notification.